### PR TITLE
Project creation from webapp interface

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,4 +36,4 @@ Written in 2014-2015 by Solomon Bessire - sbessire
 Written in 2012-2015 by Sam Hamilton - samhamilton
 Written in 2014-2015 by Yao Chunlin - chunlinyao
 Written in 2014-2015 by Abdullah Shaikh - abdullahs
-
+Written in 2015-2015 by Jens Hardings - jenshp

--- a/mantle-usl/service/mantle/work/ProjectServices.xml
+++ b/mantle-usl/service/mantle/work/ProjectServices.xml
@@ -137,18 +137,18 @@ along with this software (see the LICENSE.md file). If not, see
             <set field="clientBudgetUsedPercent" from="workEffort.totalClientCostAllowed ? ((workEffort.actualClientCost ?: 0) / workEffort.totalClientCostAllowed) * 100 : 0"/>
             <set field="clientActualOverBudget" from="workEffort.actualClientCost &gt; workEffort.totalClientCostAllowed"/>
 
-            <set field="actualPlusRemainingTime" from="workEffort.actualWorkTime + workEffort.remainingWorkTime"/>
+            <set field="actualPlusRemainingTime" from="(workEffort.actualWorkTime ?: 0) + (workEffort.remainingWorkTime ?: 0)"/>
             <set field="bestTimeEstimate" from="actualPlusRemainingTime &gt; workEffort.estimatedWorkTime ? actualPlusRemainingTime : workEffort.estimatedWorkTime "/>
             <set field="estimatedCompletePercent" from="workEffort.estimatedWorkTime ? ((workEffort.actualWorkTime ?: 0) / workEffort.estimatedWorkTime) * 100 : 0"/>
             <set field="estimatedRemainingPercent" from="workEffort.estimatedWorkTime ? ((workEffort.remainingWorkTime ?: 0) / workEffort.estimatedWorkTime) * 100 : 0"/>
-            <set field="estimatedActualPlusRemainingDiff" from="workEffort.estimatedWorkTime - actualPlusRemainingTime"/>
+            <set field="estimatedActualPlusRemainingDiff" from="(workEffort.estimatedWorkTime ?: 0) - actualPlusRemainingTime"/>
             <set field="actualPlusRemainingOverEstimated" from="actualPlusRemainingTime &gt; workEffort.estimatedWorkTime"/>
 
             <set field="clientAverageHourCost" from="workEffort.actualWorkTime ? ((workEffort.actualClientCost ?: 0) / workEffort.actualWorkTime) : 0"/>
             <set field="clientEstimatedCost" from="clientAverageHourCost * bestTimeEstimate"/>
             <set field="clientBudgetEstimateDiff" from="(workEffort.totalClientCostAllowed ?: 0) - clientEstimatedCost"/>
 
-            <set field="estimatedCompleteBudgetPercentGap" from="estimatedCompletePercent - clientBudgetUsedPercent"/>
+            <set field="estimatedCompleteBudgetPercentGap" from="(estimatedCompletePercent ?: 0) - clientBudgetUsedPercent"/>
             <set field="estimatedCompleteOverBudget" from="estimatedCompletePercent &lt; clientBudgetUsedPercent"/>
 
             <set field="projectDanger" from="clientActualOverBudget | actualPlusRemainingOverEstimated"/>


### PR DESCRIPTION
When creating a new project, workEfforts are not yet present and generate exception when displaying ProjectStats. 
With this fix, the null objects are treated as zero and the screen is displayed fully.
